### PR TITLE
feat: scheduled PR review digest to Slack

### DIFF
--- a/.github/workflows/pr-review-digest.yml
+++ b/.github/workflows/pr-review-digest.yml
@@ -1,0 +1,96 @@
+name: PR Review Digest
+
+#
+# Requirements:
+#   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
+#   ${{ secrets.GH_PAT }}                       (PAT with repo + read:org scopes)
+#
+# Posts a digest of open, non-draft pactflow org PRs with no reviews (or
+# pending review requests) that have been open for at least 1 business day.
+# Runs weekdays at 8:30am and 2:30pm AEST (UTC+10). Silent if nothing to report.
+#
+
+on:
+  schedule:
+    - cron: '30 22 * * 0-4'  # 8:30am AEST Mon–Fri (Sun–Thu UTC)
+    - cron: '30 4 * * 1-5'   # 2:30pm AEST Mon–Fri
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find unreviewed PRs and notify Slack
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+
+          # Weekend-aware cutoff: Monday runs look back 72h (covers Friday PRs)
+          DOW=$(date -u +%u)  # 1=Mon ... 7=Sun
+          if [ "$DOW" -eq 1 ]; then
+            CUTOFF=$(date -u -d '72 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          else
+            CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          fi
+
+          # Query 1: no reviews submitted
+          NO_REVIEW=$(gh search prs \
+            --owner pactflow \
+            --state open \
+            --draft=false \
+            --review=none \
+            --json number,title,url,repository,createdAt,author \
+            --limit 100)
+
+          # Query 2: review requested but not yet submitted
+          REVIEW_REQUIRED=$(gh search prs \
+            --owner pactflow \
+            --state open \
+            --draft=false \
+            --review=required \
+            --json number,title,url,repository,createdAt,author \
+            --limit 100)
+
+          # Merge, deduplicate by url, filter by cutoff
+          PRS=$(echo "$NO_REVIEW $REVIEW_REQUIRED" | jq -s '
+            [ add | unique_by(.url)[] |
+              select(.createdAt < "'"$CUTOFF"'") ] |
+            sort_by(.createdAt)
+          ')
+
+          COUNT=$(echo "$PRS" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No unreviewed PRs older than cutoff — skipping Slack notification."
+            exit 0
+          fi
+
+          # Build Slack Block Kit payload
+          NOW=$(date -u +%s)
+          BLOCKS=$(echo "$PRS" | jq --argjson now "$NOW" '
+            [
+              {
+                "type": "header",
+                "text": { "type": "plain_text", "text": "Unreviewed PRs — pactflow org", "emoji": true }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": (
+                    map(
+                      (.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $created |
+                      (($now - $created) / 86400 | floor) as $days |
+                      "• <\(.url)|\(.title)>  —  `\(.repository.name)`  —  @\(.author.login)  —  \($days)d ago"
+                    ) | join("\n")
+                  )
+                }
+              }
+            ]
+          ')
+
+          PAYLOAD=$(jq -n --argjson blocks "$BLOCKS" '{"blocks": $blocks}')
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD"

--- a/.github/workflows/pr-review-digest.yml
+++ b/.github/workflows/pr-review-digest.yml
@@ -3,10 +3,13 @@ name: PR Review Digest
 #
 # Requirements:
 #   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
-#   ${{ secrets.GH_PAT }}                       (PAT with repo + read:org scopes)
+#   ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}       (org secret — already exists)
+#   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
 #
-# Posts a digest of open, non-draft pactflow org PRs with no reviews (or
-# pending review requests) that have been open for at least 1 business day.
+# Posts a digest of open, non-draft, human-authored pactflow org PRs that:
+#   - have no reviewer assigned
+#   - have all CI checks passing
+#   - do not carry the "DO NOT MERGE" label
 # Runs weekdays at 8:30am and 2:30pm AEST (UTC+10). Silent if nothing to report.
 #
 
@@ -20,49 +23,52 @@ jobs:
   digest:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}
+          owner: pactflow
+
       - name: Find unreviewed PRs and notify Slack
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}
         run: |
           set -euo pipefail
 
-          # Weekend-aware cutoff: Monday runs look back 72h (covers Friday PRs)
-          DOW=$(date -u +%u)  # 1=Mon ... 7=Sun
-          if [ "$DOW" -eq 1 ]; then
-            CUTOFF=$(date -u -d '72 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          else
-            CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          fi
-
-          # Query 1: no reviews submitted
-          NO_REVIEW=$(gh search prs \
-            --owner pactflow \
-            --state open \
-            --draft=false \
-            --review=none \
-            --json number,title,url,repository,createdAt,author \
-            --limit 100)
-
-          # Query 2: review requested but not yet submitted
-          REVIEW_REQUIRED=$(gh search prs \
-            --owner pactflow \
-            --state open \
-            --draft=false \
-            --review=required \
-            --json number,title,url,repository,createdAt,author \
-            --limit 100)
-
-          # Merge, deduplicate by url, filter by cutoff
-          PRS=$(echo "$NO_REVIEW $REVIEW_REQUIRED" | jq -s '
-            [ add | unique_by(.url)[] |
-              select(.createdAt < "'"$CUTOFF"'") ] |
-            sort_by(.createdAt)
+          # Single GraphQL query: open, non-draft, checks passing, no reviewer assigned.
+          # Uses __typename to distinguish human Users from Bots (catches renovate-bot,
+          # dependabot, github-actions etc. without a fragile login-pattern list).
+          PRS=$(gh api graphql -f query='
+          {
+            search(query: "org:pactflow is:pr is:open draft:false review:none status:success", type: ISSUE, first: 100) {
+              nodes {
+                ... on PullRequest {
+                  title
+                  url
+                  createdAt
+                  author { login __typename }
+                  labels(first: 10) { nodes { name } }
+                  reviewRequests(first: 1) { totalCount }
+                  repository { name }
+                }
+              }
+            }
+          }' --jq '
+            [.data.search.nodes[] |
+              select(
+                (.author.__typename == "User") and
+                (.labels.nodes | map(.name) | any(. == "DO NOT MERGE") | not) and
+                (.reviewRequests.totalCount == 0)
+              )
+            ] | sort_by(.createdAt)
           ')
 
           COUNT=$(echo "$PRS" | jq 'length')
           if [ "$COUNT" -eq 0 ]; then
-            echo "No unreviewed PRs older than cutoff — skipping Slack notification."
+            echo "No PRs awaiting a reviewer — skipping Slack notification."
             exit 0
           fi
 
@@ -72,7 +78,7 @@ jobs:
             [
               {
                 "type": "header",
-                "text": { "type": "plain_text", "text": "Unreviewed PRs — pactflow org", "emoji": true }
+                "text": { "type": "plain_text", "text": "PRs awaiting a reviewer — pactflow org", "emoji": true }
               },
               {
                 "type": "section",
@@ -82,7 +88,7 @@ jobs:
                     map(
                       (.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $created |
                       (($now - $created) / 86400 | floor) as $days |
-                      "• <\(.url)|\(.title)>  —  `\(.repository.name)`  —  @\(.author.login)  —  \($days)d ago"
+                      "• <\(.url)|\(.title)>  —  `\(.repository.name)`  —  @\(.author.login)  —  :white_check_mark: \($days)d ago"
                     ) | join("\n")
                   )
                 }


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that posts a digest of PRs awaiting a reviewer across the \`pactflow\` org to Slack twice daily.

## Rules

A PR is included in the digest if **all** of the following are true:

- Open and not a draft
- Authored by a human (bots excluded via \`__typename == \"User\"\` — catches renovate-bot, dependabot, github-actions, etc.)
- No reviewer has been assigned (\`reviewRequests.totalCount == 0\`)
- All CI checks are passing (\`status:success\`)
- Does not carry the \`DO NOT MERGE\` label

## Schedule

- **8:30am AEST** Mon–Fri (\`30 22 * * 0-4\` UTC)
- **2:30pm AEST** Mon–Fri (\`30 4 * * 1-5\` UTC)

Silent if no PRs qualify — no noise on clean days.

## Secrets required

| Secret | Notes |
|--------|-------|
| \`SMARTBEAR_SLACK_WEBHOOK_URL\` | Already exists as org secret |
| \`PACTFLOW_CI_BOT_APP_ID\` | Already exists as org secret |
| \`PACTFLOW_CI_BOT_PRIVATE_KEY\` | Already exists as org secret |

A short-lived GitHub App token is generated at runtime via \`actions/create-github-app-token@v1\` — no long-lived PAT required.

## Test plan

- [ ] Merge this PR
- [ ] Trigger manually: Actions → PR Review Digest → Run workflow
- [ ] Confirm Slack message appears with correct PRs listed
- [ ] Confirm silent run when no PRs qualify

🤖 Generated with [Claude Code](https://claude.com/claude-code)