### PR TITLE
feat: draft PR reminders with per-timezone Slack @mentions

### DIFF
--- a/.github/draft-pr-slack-mapping.json
+++ b/.github/draft-pr-slack-mapping.json
@@ -1,3 +1,13 @@
 {
-  "github-login": { "slack_id": "UXXXXXXXXX", "timezone": "AEST" }
+  "Ilia":           { "slack_id": "U041B58NDMY", "timezone": "AEST" },
+  "rholshausen":    { "slack_id": "U03BGDVLP6V", "timezone": "AEST" },
+  "impurist":       { "slack_id": "U07UYLQ3PPB", "timezone": "AEST" },
+  "tuan-pham":      { "slack_id": "U05T3FXBJTC", "timezone": "AEST" },
+  "JP-Ellis":       { "slack_id": "U05NAM4B8NQ", "timezone": "AEST" },
+  "vwong":          { "slack_id": "U04KU3CEZ8T", "timezone": "AEST" },
+  "mefellows":      { "slack_id": "U03B0UU54KX", "timezone": "AEST" },
+  "prateek0411999": { "slack_id": "U079802U7KQ", "timezone": "IST"  },
+  "Saup21":         { "slack_id": "U062Y4Y51DM", "timezone": "IST"  },
+  "kevinrvaz":      { "slack_id": "U08QE19LCRM", "timezone": "IST"  },
+  "YOU54F":         { "slack_id": "U03B3R6PHPC", "timezone": "GMT"  }
 }

--- a/.github/draft-pr-slack-mapping.json
+++ b/.github/draft-pr-slack-mapping.json
@@ -1,0 +1,3 @@
+{
+  "github-login": { "slack_id": "UXXXXXXXXX", "timezone": "AEST" }
+}

--- a/.github/draft-pr-slack-mapping.json
+++ b/.github/draft-pr-slack-mapping.json
@@ -1,13 +1,13 @@
 {
-  "Ilia":           { "slack_id": "U041B58NDMY", "timezone": "AEST" },
-  "rholshausen":    { "slack_id": "U03BGDVLP6V", "timezone": "AEST" },
-  "impurist":       { "slack_id": "U07UYLQ3PPB", "timezone": "AEST" },
-  "tuan-pham":      { "slack_id": "U05T3FXBJTC", "timezone": "AEST" },
-  "JP-Ellis":       { "slack_id": "U05NAM4B8NQ", "timezone": "AEST" },
-  "vwong":          { "slack_id": "U04KU3CEZ8T", "timezone": "AEST" },
-  "mefellows":      { "slack_id": "U03B0UU54KX", "timezone": "AEST" },
-  "prateek0411999": { "slack_id": "U079802U7KQ", "timezone": "IST"  },
-  "Saup21":         { "slack_id": "U062Y4Y51DM", "timezone": "IST"  },
-  "kevinrvaz":      { "slack_id": "U08QE19LCRM", "timezone": "IST"  },
-  "YOU54F":         { "slack_id": "U03B3R6PHPC", "timezone": "GMT"  }
+  "Ilia":           { "slack_id": "U041B58NDMY", "timezone": "Australia/Melbourne" },
+  "rholshausen":    { "slack_id": "U03BGDVLP6V", "timezone": "Australia/Melbourne" },
+  "impurist":       { "slack_id": "U07UYLQ3PPB", "timezone": "Australia/Melbourne" },
+  "tuan-pham":      { "slack_id": "U05T3FXBJTC", "timezone": "Australia/Melbourne" },
+  "JP-Ellis":       { "slack_id": "U05NAM4B8NQ", "timezone": "Australia/Melbourne" },
+  "vwong":          { "slack_id": "U04KU3CEZ8T", "timezone": "Australia/Melbourne" },
+  "mefellows":      { "slack_id": "U03B0UU54KX", "timezone": "Australia/Melbourne" },
+  "prateek0411999": { "slack_id": "U079802U7KQ", "timezone": "Asia/Kolkata"         },
+  "Saup21":         { "slack_id": "U062Y4Y51DM", "timezone": "Asia/Kolkata"         },
+  "kevinrvaz":      { "slack_id": "U08QE19LCRM", "timezone": "Asia/Kolkata"         },
+  "YOU54F":         { "slack_id": "U03B3R6PHPC", "timezone": "Europe/London"        }
 }

--- a/.github/workflows/draft-pr-reminders.yml
+++ b/.github/workflows/draft-pr-reminders.yml
@@ -23,6 +23,8 @@ on:
     - cron: '0 5  * * 1'   # Mon 3pm  AEST (UTC+10) — Mon 05:00 UTC
     - cron: '30 3 * * 1'   # Mon 9am  IST  (UTC+5:30) — Mon 03:30 UTC
     - cron: '30 9 * * 1'   # Mon 3pm  IST  (UTC+5:30) — Mon 09:30 UTC
+    - cron: '0 9  * * 1'   # Mon 9am  GMT  (UTC+0)    — Mon 09:00 UTC
+    - cron: '0 15 * * 1'   # Mon 3pm  GMT  (UTC+0)    — Mon 15:00 UTC
   workflow_dispatch:
     inputs:
       timezone_group:
@@ -51,8 +53,9 @@ jobs:
             echo "group=${{ inputs.timezone_group }}" >> "$GITHUB_OUTPUT"
           else
             case "${{ github.event.schedule }}" in
-              "0 23 * * 0"|"0 5 * * 1") echo "group=AEST" >> "$GITHUB_OUTPUT" ;;
+              "0 23 * * 0"|"0 5 * * 1")  echo "group=AEST" >> "$GITHUB_OUTPUT" ;;
               "30 3 * * 1"|"30 9 * * 1") echo "group=IST"  >> "$GITHUB_OUTPUT" ;;
+              "0 9 * * 1"|"0 15 * * 1")  echo "group=GMT"  >> "$GITHUB_OUTPUT" ;;
               *) echo "group=UNKNOWN" >> "$GITHUB_OUTPUT" ;;
             esac
           fi

--- a/.github/workflows/draft-pr-reminders.yml
+++ b/.github/workflows/draft-pr-reminders.yml
@@ -7,29 +7,33 @@ name: Draft PR Reminders
 #   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
 #
 # Posts a Slack channel message @mentioning each author who has open draft PRs
-# in the pactflow org. Users are grouped by timezone so each group is notified
-# at their local 9am and 3pm on Mondays.
+# in the pactflow org. Users are grouped by IANA timezone so each group is
+# notified at their local 9am on Mondays. DST is handled automatically.
 #
 # Add users in .github/draft-pr-slack-mapping.json:
-#   { "github-login": { "slack_id": "UXXXXXXXXX", "timezone": "AEST" } }
+#   { "github-login": { "slack_id": "UXXXXXXXXX", "timezone": "Australia/Melbourne" } }
 #
-# Add a new timezone by adding two cron entries (9am + 3pm in UTC) and a
-# matching case branch in the "Resolve timezone group" step below.
+# Add a new timezone by adding a cron entry with the IANA timezone: field below.
 #
 
 on:
   schedule:
-    - cron: '0 23 * * 0'   # Mon 9am  AEST (UTC+10) — Sun 23:00 UTC
-    - cron: '0 5  * * 1'   # Mon 3pm  AEST (UTC+10) — Mon 05:00 UTC
-    - cron: '30 3 * * 1'   # Mon 9am  IST  (UTC+5:30) — Mon 03:30 UTC
-    - cron: '30 9 * * 1'   # Mon 3pm  IST  (UTC+5:30) — Mon 09:30 UTC
-    - cron: '0 9  * * 1'   # Mon 9am  GMT  (UTC+0)    — Mon 09:00 UTC
-    - cron: '0 15 * * 1'   # Mon 3pm  GMT  (UTC+0)    — Mon 15:00 UTC
+    - cron: '0 9 * * 1'
+      timezone: "Australia/Melbourne"
+    - cron: '0 9 * * 1'
+      timezone: "Asia/Kolkata"
+    - cron: '0 9 * * 1'
+      timezone: "Europe/London"
   workflow_dispatch:
     inputs:
       timezone_group:
-        description: 'Timezone group to notify (e.g. AEST, IST)'
+        description: 'Timezone group to notify'
         required: true
+        type: choice
+        options:
+          - Australia/Melbourne
+          - Asia/Kolkata
+          - Europe/London
 
 jobs:
   remind:
@@ -52,12 +56,18 @@ jobs:
           if [ -n "${{ inputs.timezone_group }}" ]; then
             echo "group=${{ inputs.timezone_group }}" >> "$GITHUB_OUTPUT"
           else
-            case "${{ github.event.schedule }}" in
-              "0 23 * * 0"|"0 5 * * 1")  echo "group=AEST" >> "$GITHUB_OUTPUT" ;;
-              "30 3 * * 1"|"30 9 * * 1") echo "group=IST"  >> "$GITHUB_OUTPUT" ;;
-              "0 9 * * 1"|"0 15 * * 1")  echo "group=GMT"  >> "$GITHUB_OUTPUT" ;;
-              *) echo "group=UNKNOWN" >> "$GITHUB_OUTPUT" ;;
-            esac
+            # All crons share the same string "0 9 * * 1" so we can't distinguish
+            # via github.event.schedule. Instead, find which configured IANA timezone
+            # currently shows 9am — that's the one whose cron just fired.
+            TIMEZONES=("Australia/Melbourne" "Asia/Kolkata" "Europe/London")
+            for tz in "${TIMEZONES[@]}"; do
+              local_hour=$(TZ="$tz" date +%H)
+              if [ "$local_hour" = "09" ]; then
+                echo "group=$tz" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            done
+            echo "group=UNKNOWN" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Find draft PRs and notify Slack

--- a/.github/workflows/draft-pr-reminders.yml
+++ b/.github/workflows/draft-pr-reminders.yml
@@ -1,0 +1,153 @@
+name: Draft PR Reminders
+
+#
+# Requirements:
+#   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
+#   ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}       (org secret — already exists)
+#   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
+#
+# Posts a Slack channel message @mentioning each author who has open draft PRs
+# in the pactflow org. Users are grouped by timezone so each group is notified
+# at their local 9am and 3pm on Mondays.
+#
+# Add users in .github/draft-pr-slack-mapping.json:
+#   { "github-login": { "slack_id": "UXXXXXXXXX", "timezone": "AEST" } }
+#
+# Add a new timezone by adding two cron entries (9am + 3pm in UTC) and a
+# matching case branch in the "Resolve timezone group" step below.
+#
+
+on:
+  schedule:
+    - cron: '0 23 * * 0'   # Mon 9am  AEST (UTC+10) — Sun 23:00 UTC
+    - cron: '0 5  * * 1'   # Mon 3pm  AEST (UTC+10) — Mon 05:00 UTC
+    - cron: '30 3 * * 1'   # Mon 9am  IST  (UTC+5:30) — Mon 03:30 UTC
+    - cron: '30 9 * * 1'   # Mon 3pm  IST  (UTC+5:30) — Mon 09:30 UTC
+  workflow_dispatch:
+    inputs:
+      timezone_group:
+        description: 'Timezone group to notify (e.g. AEST, IST)'
+        required: true
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}
+          owner: pactflow
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve timezone group
+        id: tz
+        run: |
+          if [ -n "${{ inputs.timezone_group }}" ]; then
+            echo "group=${{ inputs.timezone_group }}" >> "$GITHUB_OUTPUT"
+          else
+            case "${{ github.event.schedule }}" in
+              "0 23 * * 0"|"0 5 * * 1") echo "group=AEST" >> "$GITHUB_OUTPUT" ;;
+              "30 3 * * 1"|"30 9 * * 1") echo "group=IST"  >> "$GITHUB_OUTPUT" ;;
+              *) echo "group=UNKNOWN" >> "$GITHUB_OUTPUT" ;;
+            esac
+          fi
+
+      - name: Find draft PRs and notify Slack
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}
+          TIMEZONE_GROUP: ${{ steps.tz.outputs.group }}
+        run: |
+          set -euo pipefail
+
+          MAPPING=$(cat .github/draft-pr-slack-mapping.json)
+
+          # All open draft PRs in the org authored by humans
+          PRS=$(gh api graphql -f query='
+          {
+            search(query: "org:pactflow is:pr is:open draft:true", type: ISSUE, first: 100) {
+              nodes {
+                ... on PullRequest {
+                  title
+                  url
+                  createdAt
+                  author { login __typename }
+                  repository { name }
+                }
+              }
+            }
+          }' --jq '
+            [.data.search.nodes[] | select(.author.__typename == "User")]
+            | sort_by(.createdAt)
+          ')
+
+          COUNT=$(echo "$PRS" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No draft PRs found — skipping."
+            exit 0
+          fi
+
+          # Build one block per author in this timezone group
+          NOW=$(date -u +%s)
+          BLOCKS=$(echo "$PRS" | jq \
+            --argjson mapping "$MAPPING" \
+            --arg tz "$TIMEZONE_GROUP" \
+            --argjson now "$NOW" '
+            # Keep only PRs whose author is mapped to this timezone group
+            [.[] | . as $pr |
+              ($mapping[$pr.author.login] // null) as $user |
+              select($user != null and $user.timezone == $tz) |
+              { pr: $pr, slack_id: $user.slack_id }
+            ] |
+            if length == 0 then empty else . end |
+
+            # Group by author login
+            group_by(.pr.author.login) |
+
+            # Header block
+            [
+              {
+                "type": "header",
+                "text": { "type": "plain_text", "text": "🚧 Draft PRs needing attention — pactflow org", "emoji": true }
+              }
+            ] +
+
+            # One section per author
+            map(
+              . as $group |
+              ($group[0].slack_id) as $slack_id |
+              ($group[0].pr.author.login) as $login |
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": (
+                    "<@\($slack_id)> has \($group | length) draft PR\(if ($group | length) == 1 then "" else "s" end):\n" +
+                    (
+                      $group | map(
+                        (.pr.createdAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $created |
+                        (($now - $created) / 86400 | floor) as $days |
+                        "• <\(.pr.url)|\(.pr.title)>  —  `\(.pr.repository.name)`  —  \($days)d old"
+                      ) | join("\n")
+                    )
+                  )
+                }
+              }
+            )
+          ')
+
+          # jq exits non-zero and prints nothing if no users matched — catch that
+          if [ -z "$BLOCKS" ] || [ "$BLOCKS" = "null" ]; then
+            echo "No draft PRs for timezone group $TIMEZONE_GROUP — skipping."
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n --argjson blocks "$BLOCKS" '{"blocks": $blocks}')
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD"

--- a/.github/workflows/draft-pr-reminders.yml
+++ b/.github/workflows/draft-pr-reminders.yml
@@ -3,7 +3,7 @@ name: Draft PR Reminders
 #
 # Requirements:
 #   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
-#   ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}       (org secret — already exists)
+#   ${{ vars.PACTFLOW_CI_BOT_APP_ID }}           (org variable — already exists)
 #   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
 #
 # Posts a Slack channel message @mentioning each author who has open draft PRs
@@ -43,7 +43,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}
+          app-id: ${{ vars.PACTFLOW_CI_BOT_APP_ID }}
           private-key: ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}
           owner: pactflow
 


### PR DESCRIPTION
## Summary

- Adds a scheduled GitHub Actions workflow (`draft-pr-reminders.yml`) that notifies authors of open draft PRs in the pactflow org via Slack @mention every Monday
- Each timezone group is notified at their local 9am and 3pm — AEST, IST, and GMT supported
- Adds `draft-pr-slack-mapping.json` mapping 11 team members (GitHub login → Slack member ID + timezone)

## How it works

1. A GitHub App token is used to query all `draft:true` open PRs across the org via GraphQL
2. Results are filtered to only authors in the current timezone group (based on which cron fired)
3. A Block Kit Slack message is posted to the configured webhook channel, @mentioning each author with their draft PR(s) and age

## Cron schedule

| Timezone | 9am trigger | 3pm trigger |
|---|---|---|
| AEST (UTC+10) | Sun 23:00 UTC | Mon 05:00 UTC |
| IST (UTC+5:30) | Mon 03:30 UTC | Mon 09:30 UTC |
| GMT (UTC+0) | Mon 09:00 UTC | Mon 15:00 UTC |

## Adding users / timezones

- **New user:** add an entry to `.github/draft-pr-slack-mapping.json`
- **New timezone:** add two cron lines (9am + 3pm in UTC) and a matching `case` branch in the workflow

## Test plan

- [ ] Trigger manually via `workflow_dispatch` with `timezone_group=AEST` — verify Slack message appears with correct @mentions
- [ ] Trigger with a group that has no draft PRs — confirm silent exit (no Slack post)
- [ ] Verify `mefellows` maps correctly if Matt has a draft PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)