### PR TITLE
fix: use vars. for PACTFLOW_CI_BOT_APP_ID in PR review digest

### DIFF
--- a/.github/workflows/pr-review-digest.yml
+++ b/.github/workflows/pr-review-digest.yml
@@ -3,7 +3,7 @@ name: PR Review Digest
 #
 # Requirements:
 #   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
-#   ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}       (org secret — already exists)
+#   ${{ vars.PACTFLOW_CI_BOT_APP_ID }}           (org variable — already exists)
 #   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
 #
 # Posts a digest of open, non-draft, human-authored pactflow org PRs that:
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.PACTFLOW_CI_BOT_APP_ID }}
+          app-id: ${{ vars.PACTFLOW_CI_BOT_APP_ID }}
           private-key: ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}
           owner: pactflow
 


### PR DESCRIPTION
## Summary

- Fixes `PACTFLOW_CI_BOT_APP_ID` reference from `secrets.` to `vars.` — the App ID is stored as an org variable, not a secret, causing the `create-github-app-token` action to fail with "Input required and not supplied: app-id"

## Root cause

Run [#26801743037](https://github.com/pactflow/.github/actions/runs/26801743037/job/79009714809) failed with:
```
Error: Input required and not supplied: app-id
```
`${{ secrets.PACTFLOW_CI_BOT_APP_ID }}` resolved to empty because the value is stored as an Actions variable (`vars.`), not a secret.

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` and confirm the GitHub App token step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)