### PR TITLE
fix: move PR digest schedule 45min earlier (7:45am and 1:45pm AEST)

### DIFF
--- a/.github/workflows/pr-review-digest.yml
+++ b/.github/workflows/pr-review-digest.yml
@@ -15,8 +15,8 @@ name: PR Review Digest
 
 on:
   schedule:
-    - cron: '30 22 * * 0-4'  # 8:30am AEST Mon–Fri (Sun–Thu UTC)
-    - cron: '30 4 * * 1-5'   # 2:30pm AEST Mon–Fri
+    - cron: '45 21 * * 0-4'  # 7:45am AEST Mon–Fri (Sun–Thu UTC)
+    - cron: '45 3 * * 1-5'   # 1:45pm AEST Mon–Fri
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Shifts both daily digest runs 45 minutes earlier:
- 8:30am → 7:45am AEST (`45 21 * * 0-4` UTC)
- 2:30pm → 1:45pm AEST (`45 3 * * 1-5` UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)