### PR TITLE
chore: retire pr-review-digest cron triggers

### DIFF
--- a/.github/workflows/pr-review-digest.yml
+++ b/.github/workflows/pr-review-digest.yml
@@ -1,20 +1,23 @@
 name: PR Review Digest
 
 #
+# Cron triggers retired — the scheduled digest now runs from
+# pactflow/coverage-dashboard's pr-review-digest.yml, which decorates
+# each digest with portfolio stats (coverage, pact pass rate, health
+# score) and a per-person review-this-past-week podium pulled from the
+# dashboard's SQLite. See:
+#   https://github.com/pactflow/coverage-dashboard/blob/main/.github/workflows/pr-review-digest.yml
+#
+# Kept manual-only so it can be re-fired from the Actions tab as a
+# fallback if the new workflow ever breaks.
+#
 # Requirements:
 #   ${{ secrets.SMARTBEAR_SLACK_WEBHOOK_URL }}  (org secret — already exists)
 #   ${{ vars.PACTFLOW_CI_BOT_APP_ID }}           (org variable — already exists)
 #   ${{ secrets.PACTFLOW_CI_BOT_PRIVATE_KEY }}  (org secret — already exists)
 #
-# Posts a digest of all open, non-draft pactflow org PRs authored by someone
-# in .github/draft-pr-slack-mapping.json. Runs weekdays at 7:45am and 1:45pm
-# AEST/AEDT. Silent if nothing to report.
-#
 
 on:
-  schedule:
-    - cron: '45 21 * * 0-4'  # 7:45am AEST Mon–Fri (Sun–Thu UTC)
-    - cron: '45 3 * * 1-5'   # 1:45pm AEST Mon–Fri
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary

The scheduled PR review digest **moved to [pactflow/coverage-dashboard](https://github.com/pactflow/coverage-dashboard/pull/9)** — the new workflow decorates each digest with portfolio stats (coverage %, pact pass rate, health score) and a per-person "reviews this past week" podium pulled from the dashboard's SQLite.

This PR removes the two cron triggers (07:45 + 13:45 AEST Mon–Fri) so we don't get **double Slack posts** at every tick.

\`workflow_dispatch\` is kept on the inputs so the original digest can still be fired manually from the Actions tab as a fallback if the new workflow ever breaks.

## Diff

```diff
 on:
-  schedule:
-    - cron: '45 21 * * 0-4'  # 7:45am AEST Mon–Fri (Sun–Thu UTC)
-    - cron: '45 3 * * 1-5'   # 1:45pm AEST Mon–Fri
   workflow_dispatch:
     inputs:
       dry_run:
         description: 'Print digest to the log without posting to Slack'
         type: boolean
         default: false
```

Plus a one-paragraph header comment explaining where the live digest now lives.

## Mapping JSON

\`.github/draft-pr-slack-mapping.json\` is **unchanged** in this PR. Both reasons:

1. The retired workflow still reads it on the manual-fallback path.
2. The new coverage-dashboard workflow has its own copy with a \`display_name\` field added — so the digest reads _"Ron has 2 PRs to review"_ rather than _"rholshausen has 2 PRs to review"_.

If/when we delete this workflow entirely, the local mapping JSON should go with it. Long term, the canonical version lives in coverage-dashboard.

## Test plan

- [x] Diff verifies cron block removed, `workflow_dispatch:` retained
- [ ] Reviewer: after merge, manual-dispatch this workflow once with `dry_run=true` — confirm it still runs as a fallback
- [ ] Reviewer: confirm the next 07:45 AEST tick only posts once (from coverage-dashboard, not here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)